### PR TITLE
Added performance test to compare RegExp based solution and the try-catch based implementation.

### DIFF
--- a/ddprofiler/src/main/java/preanalysis/PreAnalyzer.java
+++ b/ddprofiler/src/main/java/preanalysis/PreAnalyzer.java
@@ -95,7 +95,7 @@ public class PreAnalyzer implements PreAnalysis, IO {
 					+ "(((0[xX](\\p{XDigit}+)(\\.)?)|(0[xX](\\p{XDigit}+)?(\\.)(\\p{XDigit}+)))"
 					+ "[pP][+-]?(\\p{Digit}+)))[fFdD]?))[\\x00-\\x20]*");
 
-	private static boolean isNumberical(String s) {
+	public static boolean isNumberical(String s) {
 		return DOUBLE_PATTERN.matcher(s).matches();
 	}
 

--- a/ddprofiler/src/test/java/test/PreAnalyzerTest.java
+++ b/ddprofiler/src/test/java/test/PreAnalyzerTest.java
@@ -4,6 +4,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Random;
+import java.util.Vector;
 
 import org.junit.Test;
 
@@ -57,6 +59,66 @@ public class PreAnalyzerTest {
 				}
 			}
 		}
+	}
+	
+	
+	public void workloadTest(List<String> test_strings, PreAnalyzer pa){
+		long startTime = System.currentTimeMillis();
+		for(int i=0; i<test_strings.size(); i++){
+			pa.isNumbericalExpcetion(test_strings.get(i));
+		}
+		long endTime = System.currentTimeMillis();
+		System.out.println("Exception method took: " + (endTime - startTime) + " milliseconds");
+		System.out.println("----------------------------------------------------------------\n\n");
+
+		System.out.println("Using Reg Exp based solution with workloads that are all numerical values");
+		startTime = System.currentTimeMillis();
+		for(int i=0; i<test_strings.size(); i++){
+			pa.isNumberical(test_strings.get(i));
+		}
+		endTime = System.currentTimeMillis();
+		System.out.println("Reg Exp based method took: " + (endTime - startTime) + " milliseconds");
+
+	}
+	
+	@Test
+	public void testRegExpPerformance(){
+		PreAnalyzer pa = new PreAnalyzer();
+		final int NUM_TEST_STRINGS=1000000;
+		final double DOUBLE_RANGLE_MIN=1.0;
+		final double DOUBLE_RANGLE_MAX=10000000.0;
+		List<String> testStrings = new Vector<String>();
+		double start = DOUBLE_RANGLE_MIN;
+		double end = DOUBLE_RANGLE_MAX;
+		Random randomSeeds = new Random();
+
+		for(int i=0; i<NUM_TEST_STRINGS; i++){
+			double randomGen = randomSeeds.nextDouble();
+			double result = start + (randomGen * (end - start));
+			testStrings.add(result+"");
+		}
+		
+		//testing workloads that are numberical values, in this case the try-catch approach will not never incur an exception
+		System.out.println("Test with workloads that are all numerical values");
+		workloadTest(testStrings, pa);
+		System.out.println("----------------------------------------------------------------\n\n");
+
+		
+		for(int i=0; i<NUM_TEST_STRINGS/2; i++){
+			testStrings.set(i, "A");
+		}
+		
+		System.out.println("Test with workloads that half of them are numberical values");
+		workloadTest(testStrings, pa);
+		System.out.println("----------------------------------------------------------------\n\n");
+
+		for(int i=NUM_TEST_STRINGS/2; i<NUM_TEST_STRINGS; i++){
+			testStrings.set(i, "A");
+		}
+		System.out.println("Test with workloads that all them are numberical values");
+		workloadTest(testStrings, pa);
+		System.out.println("----------------------------------------------------------------\n\n");
+
 	}
 
 }


### PR DESCRIPTION
Compared three different workdloads. The first workload all includes numerical values; the second workload includes half numerical values; the third workload includes no numerical values.

Below are some testing results for a workload with 100000 strings. When the workload include only numerical values, the try-catch method is actually slightly faster than the regular expression based method. This makes sense because the try-catch based method only incurs penalty when there are parsing exceptions. When half (resp. none) of the workload are non-numerical values, the regular expression based method is 3x (resp. 8) faster than the try-catch based solution.

Test with workloads that are all numerical values
## Exception method took: 353 milliseconds

Using Reg Exp based solution with workloads that are all numerical values
## Reg Exp based method took: 382 milliseconds

Test with workloads that half of them are numerical values
## Exception method took: 1146 milliseconds

Using Reg Exp based solution with workloads that are all numerical values
## Reg Exp based method took: 314 milliseconds

Test with workloads that all them are numerical values
## Exception method took: 2000 milliseconds

Using Reg Exp based solution with workloads that are all numerical values
## Reg Exp based method took: 248 milliseconds
