### PR TITLE
add readRow to DBConnector

### DIFF
--- a/ddprofiler/src/main/java/inputoutput/conn/Connector.java
+++ b/ddprofiler/src/main/java/inputoutput/conn/Connector.java
@@ -8,6 +8,8 @@ package inputoutput.conn;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -24,6 +26,38 @@ public abstract class Connector {
 	abstract void destroyConnector();
 	public abstract List<Attribute> getAttributes() throws IOException, SQLException;
 	public abstract boolean readRows(int num, List<Record> rec_list) throws IOException, SQLException;
-	public abstract Map<Attribute, List<String>> readRows(int num) throws IOException, SQLException;
+	/**
+	 * Returns a map with Attribute of table as key and a list of num values as value.
+	 * Map is created internally as it must preserve insertion order
+	 * @param num
+	 * @return
+	 * @throws IOException
+	 * @throws SQLException
+	 */
+	public Map<Attribute, List<String>> readRows(int num) throws IOException, SQLException {
+		
+		Map<Attribute, List<String>> data = new LinkedHashMap<>();
+		// Make sure attrs is populated, if not, populate it here
+		if(data.isEmpty()) {
+			List<Attribute> attrs = this.getAttributes();
+			attrs.forEach(a -> data.put(a, new ArrayList<>()));
+		}
+		
+		// Read data and insert in order
+		List<Record> recs = new ArrayList<>();
+		boolean readData = this.readRows(num, recs);
+		if(!readData) {
+			return null;
+		}
+		for(Record r : recs) {
+			List<String> values = r.getTuples();			
+			int currentIdx = 0;
+			for(List<String> vals : data.values()) { // ordered iteration
+				vals.add(values.get(currentIdx));
+				currentIdx++;
+			}
+		}
+		return data;
+	}
 	
 }

--- a/ddprofiler/src/main/java/inputoutput/conn/DBConnector.java
+++ b/ddprofiler/src/main/java/inputoutput/conn/DBConnector.java
@@ -115,6 +115,8 @@ public class DBConnector extends Connector {
 
 	@Override
 	public List<Attribute> getAttributes() throws SQLException {
+		if(tb_info.getTableAttributes() != null)
+			return tb_info.getTableAttributes();
 		DatabaseMetaData metadata = conn.getMetaData();
 		ResultSet resultSet = metadata.getColumns(null, null, sourceName, null);
 		Vector<Attribute> attrs  = new Vector<Attribute>();
@@ -125,6 +127,7 @@ public class DBConnector extends Connector {
 			Attribute attr = new Attribute(name, type, size);
 			attrs.addElement(attr);
 		}
+		tb_info.setTableAttributes(attrs);
 		return attrs;
 	}
 	
@@ -203,11 +206,6 @@ public class DBConnector extends Connector {
 		this.stat = stat;
 	}
 
-	@Override
-	public Map<Attribute, List<String>> readRows(int num) throws IOException, SQLException {
-		// TODO Auto-generated method stub
-		return null;
-	}
 
 	@Override
 	public String getSourceName() {

--- a/ddprofiler/src/main/java/inputoutput/conn/FileConnector.java
+++ b/ddprofiler/src/main/java/inputoutput/conn/FileConnector.java
@@ -113,40 +113,6 @@ public class FileConnector extends Connector {
 
 	int debug_cnt=0;
 
-	/**
-	 * Returns a map with Attribute of table as key and a list of num values as value.
-	 * Map is created internally as it must preserve insertion order
-	 * @param num
-	 * @return
-	 * @throws IOException
-	 * @throws SQLException
-	 */
-	@Override
-	public Map<Attribute, List<String>> readRows(int num) throws IOException, SQLException {
-		
-		Map<Attribute, List<String>> data = new LinkedHashMap<>();
-		// Make sure attrs is populated, if not, populate it here
-		if(data.isEmpty()) {
-			List<Attribute> attrs = this.tableInfo.getTableAttributes();
-			attrs.forEach(a -> data.put(a, new ArrayList<>()));
-		}
-		
-		// Read data and insert in order
-		List<Record> recs = new ArrayList<>();
-		boolean readData = this.readRows(num, recs);
-		if(!readData) {
-			return null;
-		}
-		for(Record r : recs) {
-			List<String> values = r.getTuples();			
-			int currentIdx = 0;
-			for(List<String> vals : data.values()) { // ordered iteration
-				vals.add(values.get(currentIdx));
-				currentIdx++;
-			}
-		}
-		return data;
-	}
 
 	
 	/*


### PR DESCRIPTION
didn't add new code. The implementation of readRow function is independent of the type of connectors. As a result, it can be moved into the Connector base class. An issue for the DBConnector getAttributes function is that it will try to load the attributes from database when it calls the readRow function. Add a null check operation to avoid repeatedly getting the attributes from the database.

Tested it on MySQL and works fine. Installed Oracle 11g today and will test it on Oracle.

PS.

The installed Oracle does not work on my machine though.
