### PR TITLE
Improve entity analysis and set automatic threshold for early stopping

### DIFF
--- a/ddprofiler/src/main/java/analysis/modules/EntityAnalyzer.java
+++ b/ddprofiler/src/main/java/analysis/modules/EntityAnalyzer.java
@@ -9,8 +9,10 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.Vector;
@@ -19,31 +21,88 @@ import analysis.AnalyzerFactory;
 import analysis.TextualDataConsumer;
 import opennlp.tools.namefind.NameFinderME;
 import opennlp.tools.namefind.TokenNameFinderModel;
+import opennlp.tools.tokenize.SimpleTokenizer;
+import opennlp.tools.tokenize.Tokenizer;
 import opennlp.tools.util.Span;
 
 public class EntityAnalyzer implements TextualDataConsumer {
 
+	private class EntityAnalyzerStatistics{
+		private String nameFinderStr;
+		private int hitCount;// the number of strings that matches a certain OpenNLP model.
+		private double avgProb = 0.0;//each match in the hitCount will include a probability to show its confidence,
+		//avgProb = sum of these prob / hitCount
+		
+
+		private double feedTokenAvgCount = 0.0;//each textual input will be tokenized into several words, 
+		//the feedTokenAvgCount = the total number of such tokened words / the number of input records;
+		
+		private int feedCount = 0;//the number of records feeded into the EntityAnalyzer
+		
+		public EntityAnalyzerStatistics(String nameFinderStr){
+			this.setNameFinderStr(nameFinderStr);
+		}
+		public String getNameFinderStr() {
+			return nameFinderStr;
+		}
+		public void setNameFinderStr(String nameFinderStr) {
+			this.nameFinderStr = nameFinderStr;
+		}
+		
+		public int getHitCount() {
+			return hitCount;
+		}
+		
+		public void updateAverageProb(double prob){
+			hitCount++;
+			this.avgProb = ((hitCount-1)* this.avgProb + prob )/hitCount;
+		}
+		public double getAvgProb() {
+			// TODO Auto-generated method stub
+			return avgProb;
+		}
+
+		public void updateAvgFeedTokenCount(int incFeedTokenCount) {
+			this.feedCount++;
+			this.feedTokenAvgCount = (incFeedTokenCount + this.feedTokenAvgCount*(feedCount-1))/feedCount;
+		}
+		
+		public String toString(){
+			return this.nameFinderStr + " " + this.feedTokenAvgCount + " "+this.hitCount + " " + this.avgProb;
+		}
+	}
+	
 	private Set<String> entities = null;
 	private List<NameFinderME> nameFinderList = null;
 	private Properties prop = null;
-
+	private Tokenizer tok = SimpleTokenizer.INSTANCE;
 	private List<TokenNameFinderModel> modelList = null;
+	private Map<NameFinderME, EntityAnalyzerStatistics> eaStatics; 
+	private List<String> modelNameList = null;
+	private boolean isConverged = false;
+	private EntityAnalyzerStatistics lastConvergedEAStat=null;
 	
-	public EntityAnalyzer(List<TokenNameFinderModel> modelList) {
+	public EntityAnalyzer(List<TokenNameFinderModel> modelList, List<String> modelNameList) {
 		prop = new Properties(); 
 		entities = new HashSet<>();
 		nameFinderList = new Vector<NameFinderME>();
+		this.modelNameList = modelNameList;
+		eaStatics = new HashMap<NameFinderME, EntityAnalyzerStatistics>();
 		
-		for (TokenNameFinderModel tf_model : modelList) {
-			NameFinderME nameFinder = new NameFinderME(tf_model);
+		for(int i=0; i<modelList.size(); i++){
+			NameFinderME nameFinder = new NameFinderME(modelList.get(i));
 			nameFinderList.add(nameFinder);
+			eaStatics.put(nameFinder, new EntityAnalyzerStatistics(modelNameList.get(i)));
 		}
+		
 	}
 	
 	public EntityAnalyzer() {
 		prop = new Properties(); 
 		entities = new HashSet<>();
 		nameFinderList = new Vector<NameFinderME>();
+		modelNameList = new Vector<String>();
+		eaStatics = new HashMap<NameFinderME, EntityAnalyzerStatistics>();
 		
 		InputStream nlpModeConfigStream;
 		try {
@@ -59,14 +118,19 @@ public class EntityAnalyzer implements TextualDataConsumer {
 			e.printStackTrace();
 		}
 		
-		for (TokenNameFinderModel tf_model : modelList) {
-			NameFinderME nameFinder = new NameFinderME(tf_model);
+		for (int i=0; i<modelList.size(); i++) {
+			NameFinderME nameFinder = new NameFinderME(modelList.get(i));
 			nameFinderList.add(nameFinder);
+			eaStatics.put(nameFinder, new EntityAnalyzerStatistics(modelNameList.get(i)));
 		}
 	}
 	
 	public List<TokenNameFinderModel> getCachedModelList() {
 		return modelList;
+	}
+	
+	public List<String> getCachedModelNameList(){
+		return this.modelNameList;
 	}
 
 	public Entities getEntities() {
@@ -74,24 +138,114 @@ public class EntityAnalyzer implements TextualDataConsumer {
 		return e;
 	}
 
+	
+	private String[] preprocessFeedString(String[] strArr, String modelName){
+		
+		/*
+		 * current person and location model cannot recognize the entity based on the string
+		 * unless the first char of the string is 
+		 * upper case and the latters are lower cases.
+		*/
+		
+		if(modelName.equals("person") || modelName.equals("location")){
+			//first convert all chars to lower case, and then set the first to upper case.
+			String[] retArr = new String[strArr.length];
+			for(int i=0; i<strArr.length; i++){
+				String val = strArr[i].trim().toLowerCase();
+				if(val.length() ==0){
+					retArr[i] = val;
+				}else
+					retArr[i] = val.substring(0,1).toUpperCase() + val.substring(1);
+			}
+			return retArr;
+		}
+		//TODO: does other models need preprocessing? 
+		
+		return strArr;
+	}
+	
+	@SuppressWarnings("unused")
+	private void printEAStatics(){
+		for(Map.Entry<NameFinderME, EntityAnalyzerStatistics> ent: eaStatics.entrySet()){
+			EntityAnalyzerStatistics stat = ent.getValue();
+			if(stat.avgProb > 0.0)
+				System.out.println(stat);
+		}
+	}
+	
+	// check whether entity recognition has converged
+	private boolean estimateConverged(){
+		
+		printEAStatics();
+		
+		//if the identified entity is the same as the last one, and its probability is larger than 0.5
+		//then we regard it as converged.		
+		
+		EntityAnalyzerStatistics dominateAnalyzer = null;
+		for(Map.Entry<NameFinderME, EntityAnalyzerStatistics> ent: eaStatics.entrySet()){
+			EntityAnalyzerStatistics eas = ent.getValue();
+			if( eas.getAvgProb() > 0.0){
+				
+				//TODO: do we compare hitCount? i.e., the number of strings that matches a certain type? 
+				if(dominateAnalyzer != null){
+					if(dominateAnalyzer.getAvgProb() < eas.getAvgProb()){
+						dominateAnalyzer = eas;
+					}
+				}else{
+					dominateAnalyzer = eas;
+				}
+			}
+		}
+		
+		if(dominateAnalyzer != null && lastConvergedEAStat == null){
+			lastConvergedEAStat = dominateAnalyzer;
+		}
+		if( dominateAnalyzer !=null && dominateAnalyzer == lastConvergedEAStat 
+				&& dominateAnalyzer.avgProb>0.5){
+			//converged
+			return true;
+		}
+		
+		return false;
+	}
+	
 	@Override
 	public boolean feedTextData(List<String> records) {
 		// TODO: preprocessing to records?
+		
+		if(isConverged){
+			System.out.println("Converged");
+			return false;
+		}
+		
 		String[] sentences = new String[records.size()];
 		for (int i = 0; i < sentences.length; i++) {
 			sentences[i] = records.get(i);
 		}
 		for (NameFinderME nameFinder : nameFinderList) {
-			Span nameSpans[] = nameFinder.find(sentences);
-
-			for (Span s : nameSpans) {
-				entities.add(s.getType());
+			EntityAnalyzerStatistics eas = eaStatics.get(nameFinder);
+			for(int i=0; i<sentences.length; i++){
+				String[] inputStr = preprocessFeedString(tok.tokenize(sentences[i]),
+						eas.getNameFinderStr()) ;
+				eas.updateAvgFeedTokenCount(inputStr.length);
+				Span nameSpans[] = nameFinder.find(inputStr);
+				
+				for (Span s : nameSpans) {
+					entities.add(s.getType());
+					eas.updateAverageProb(s.getProb());;
+				}
 			}
-
+			
+			
 			// This is supposed to be called temporarily to clean up data
 			nameFinder.clearAdaptiveData();
+			
 		}
-
+		
+		
+		//printEAStatics();
+		isConverged = estimateConverged();
+		
 		return false;
 	}
 
@@ -117,6 +271,7 @@ public class EntityAnalyzer implements TextualDataConsumer {
 					modelIn = new FileInputStream(value);
 					model = new TokenNameFinderModel(modelIn);
 					modelList.add(model);
+					modelNameList.add(key);
 				} 
 				catch (IOException e) {
 					e.printStackTrace();

--- a/ddprofiler/src/main/java/core/Conductor.java
+++ b/ddprofiler/src/main/java/core/Conductor.java
@@ -51,6 +51,7 @@ public class Conductor {
 		List<String> uniqueThreadNames = new ArrayList<>();
 		cachedEntityAnalyzers = new HashMap<>();
 		List<TokenNameFinderModel> modelList = new ArrayList<>();
+		List<String> modelNameList = new ArrayList<>();
 		for(int i = 0; i < numWorkers; i++) {
 			String name = "Thread-"+new Integer(i).toString();
 			uniqueThreadNames.add(name);
@@ -58,9 +59,10 @@ public class Conductor {
 				EntityAnalyzer first = new EntityAnalyzer();
 				cachedEntityAnalyzers.put(name, first); // pay cost of loading model
 				modelList = first.getCachedModelList();
+				modelNameList = first.getCachedModelNameList();
 			}
 			else{
-				cachedEntityAnalyzers.put(name, new EntityAnalyzer(modelList));
+				cachedEntityAnalyzers.put(name, new EntityAnalyzer(modelList,modelNameList));
 			}
 		}
 		this.pool = Executors.newFixedThreadPool(numWorkers, new DDThreadFactory(uniqueThreadNames));

--- a/ddprofiler/src/test/java/test/AnalyzerTest.java
+++ b/ddprofiler/src/test/java/test/AnalyzerTest.java
@@ -2,6 +2,7 @@ package test;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -23,8 +24,8 @@ import preanalysis.Values;
 
 public class AnalyzerTest {
 
-	private String path = "C:\\";
-	private String filename = "Leading_Causes_of_Death__1990-2010.csv";
+	private String path = "C:\\csv\\";
+	private String filename = "dataset1.csv";
 	//private String path = "/Users/ra-mit/Desktop/mitdwhdata/";
 	//private String filename = "short_cis_course_catalog.csv";
 	private String separator = ",";
@@ -49,6 +50,7 @@ public class AnalyzerTest {
 		//pa.composeConnector(dbc);
 		
 		Map<Attribute, Values> data = pa.readRows(numRecords);
+		Map<Attribute, TextualAnalysis> taMapping = new HashMap<Attribute, TextualAnalysis>();
 		for(Entry<Attribute, Values> a : data.entrySet()) {
 			System.out.println("CName: "+a.getKey().getColumnName());
 			System.out.println("CType: "+a.getKey().getColumnType());
@@ -71,6 +73,7 @@ public class AnalyzerTest {
 			}
 			if(at.equals(AttributeType.STRING)) {
 				TextualAnalysis ta = AnalyzerFactory.makeTextualAnalyzer();
+				taMapping.put(a.getKey(), ta);
 				List<String> strs = new ArrayList<>();
 				for(String s : a.getValue().getStrings()) {
 					strs.add(s);
@@ -84,8 +87,54 @@ public class AnalyzerTest {
 				System.out.println("Entities:");
 				System.out.println(e);
 			}
+			break;
+		}
+		
+		
+		for(int i=0; i<20; i++){
+			data = pa.readRows(numRecords);
+			if(data == null) break;
+			for(Entry<Attribute, Values> a : data.entrySet()) {
+				System.out.println("CName: "+a.getKey().getColumnName());
+				System.out.println("CType: "+a.getKey().getColumnType());
+				AttributeType at = a.getKey().getColumnType();
+				if(at.equals(AttributeType.FLOAT)) {
+					NumericalAnalysis na = AnalyzerFactory.makeNumericalAnalyzer();
+					List<Float> floats = new ArrayList<>();
+					for(Float s : a.getValue().getFloats()) {
+						floats.add(s);
+					}
+	
+					na.feedFloatData(floats);
+					Cardinality c = na.getCardinality();
+					Range r = na.getNumericalRange(AttributeType.FLOAT);
+					System.out.println("Cardinality:");
+					System.out.println(c);
+					System.out.println("Range:");
+					System.out.println(r);
+					System.out.println("median: "+na.getQuantile(0.5));
+				}
+				if(at.equals(AttributeType.STRING)) {
+					TextualAnalysis ta = taMapping.get(a.getKey());
+					List<String> strs = new ArrayList<>();
+					for(String s : a.getValue().getStrings()) {
+						strs.add(s);
+					}
+	
+					ta.feedTextData(strs);
+					Cardinality c = ta.getCardinality();
+					Entities e = ta.getEntities();
+					System.out.println("Cardinality:");
+					System.out.println(c);
+					System.out.println("Entities:");
+					System.out.println(e);
+				}
+				break;
+			}
 		}
 		
 	}
+	
+	
 
 }


### PR DESCRIPTION
1. Use built-in tokenizer to first split the input text into different
   parts, and then feed it into the analyzer. 
2. The person/location model can only recognize records that the first
   char is upper case. Added input preprocessing for these two models. 
3. add convergence test. In current implementation, the convergence test
   check if the current estimated type with maximum probability is still
   the maximum after another around reading of data. If the answer is yes, then it
   skip the entity analyzing part. Otherwise, it will further feed the
   records to entity analyzer until the above stopping condition meets.
