### PR TITLE
Fix reporting one direction

### DIFF
--- a/api/reporting.py
+++ b/api/reporting.py
@@ -51,18 +51,16 @@ class Report:
             Relation.CONTENT_SIM)
         # FIXME: counting twice (both directions), so /2. Once edges works, we
         # can modify it
-        total_content_sim_relations = len(
-            [x for x in content_sim_relations_gen]) / 2
+        total_content_sim_relations = len([x for x in content_sim_relations_gen])
         self.__num_content_sim_relations = total_content_sim_relations
 
         schema_sim_relations_gen = self.__network.enumerate_relation(
             Relation.SCHEMA_SIM)
-        total_schema_sim_relations = len(
-            [x for x in schema_sim_relations_gen]) / 2
+        total_schema_sim_relations = len([x for x in schema_sim_relations_gen])
         self.__num_schema_sim_relations = total_schema_sim_relations
 
         pkfk_relations_gen = self.__network.enumerate_relation(Relation.PKFK)
-        total_pkfk_relations = len([x for x in pkfk_relations_gen]) / 2
+        total_pkfk_relations = len([x for x in pkfk_relations_gen])
         self.__num_pkfk_relations = total_pkfk_relations
 
         return self

--- a/knowledgerepr/fieldnetwork.py
+++ b/knowledgerepr/fieldnetwork.py
@@ -159,13 +159,16 @@ class FieldNetwork:
         return topk_nodes
 
     def enumerate_relation(self, relation):
+        seen_pairs = set()
         for nid in self.iterate_ids():
             db_name, source_name, field_name, data_type = self.__id_names[nid]
             hit = Hit(nid, db_name, source_name, field_name, 0)
             neighbors = self.neighbors_id(hit, relation)
             for n2 in neighbors:
-                string = str(hit) + " - " + str(n2)
-                yield string
+                if not (n2.nid, nid) in seen_pairs:
+                    seen_pairs.add((nid, n2.nid))
+                    string = str(hit) + " - " + str(n2)
+                    yield string
 
     def print_relations(self, relation):
         total_relationships = 0


### PR DESCRIPTION
fix the edges reporting function, e.g, print_pkfk_relations() and num_pkfk_relations, to print edges in one direction only, i.e., not twice. 