### PR TITLE
Streamline docker setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@
 # 1. docker-compose up -d elasticsearch
 #     Brings up an elasticsearch instance using the data located at data/elasticsearch. This data persists even if you destroy and recreate the elasticsearch Docker container.
 # 2*. docker-compose build profiler
-# 2. docker-compose run --rm -T profiler -e "<profiler args here>"
+# 2. docker-compose up profiler
 #     Runs the ddprofiler with the CSVs located in data/csvs. Writes to the above elasticsearch container.
 # 3*. docker-compose build nbc
 # 3. docker-compose run --rm -T nbc
@@ -42,6 +42,7 @@ services:
       dockerfile: docker/Dockerfile-ddprofiler
     volumes:
       - ./data:/data
+    command: ""  # "<profiler args here>"
     networks:
       aurum_net:
         aliases:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,9 +42,6 @@ services:
       dockerfile: docker/Dockerfile-ddprofiler
     volumes:
       - ./data:/data
-    ports:
-      - 9200:9200
-      - 9300:9300
     networks:
       aurum_net:
         aliases:

--- a/docker/Dockerfile-networkbuildercoordinator
+++ b/docker/Dockerfile-networkbuildercoordinator
@@ -19,7 +19,7 @@ RUN pip3 install --upgrade pip
 
 COPY requirements.txt /tmp/
 
-RUN pip3 install -r /tmp/requirements.txt --no-cache-dir
+RUN pip3 install -r /tmp/requirements.txt --no-cache-dir --ignore-installed
 
 RUN python3 -c "import matplotlib; import matplotlib.pyplot"
 


### PR DESCRIPTION
- I added a `-ignore-installed` flagged to the pip3 installation command of the networkbuildercoordinator to ensure a consistent installation procedure across enviroments/infrastructures.

- removed the ports specified for the `profiler` service since they are obsolete in this service and conflict with the `elasticsearch` service

- added the command attribute for the `profiler` to hold the profiler arguments (since this is appended to the `ENTRYPOINT` on execution). This will allow to run the profiler by simply running `docker-compose up profiler` and allows for easy override in `docker-compose.override.yml`