### PR TITLE
Fixing api.intersection() in apiutils.py 

### DIFF
--- a/api/apiutils.py
+++ b/api/apiutils.py
@@ -489,34 +489,42 @@ class DRS:
         # FIXME: perhaps we need to do some garbage collection of the prov graph at some point
         # FIXME: or alternatively perform a more fine-grained merging
         # self.absorb_provenance(drs, annotate_and_edges=True)
-        result.absorb_provenance(drs, annotate_and_edges=True)
         result.absorb_provenance(self, annotate_and_edges=True)
+        result.absorb_provenance(drs, annotate_and_edges=True)
         return result
 
     def union(self, drs):
         # Reset ranking
         self._ranked = False
+        result = DRS([], Operation(OP.NONE))
         merging_data = set(drs.data)
         my_data = set(self.data)
         new_data = merging_data.union(my_data)
-        self.set_data(list(new_data))
+        # self.set_data(list(new_data))
+        result.set_data(list(new_data))
         # Merge provenance
         # FIXME: perhaps we need to do some garbage collection of the prov
         # graph at some point
-        self.absorb_provenance(drs)
-        return self
+        # self.absorb_provenance(drs)
+        result.absorb_provenance(self)
+        result.absorb_provenance(drs)
+        return result
 
     def set_difference(self, drs):
         # Reset ranking
         self._ranked = False
+        result = DRS([], Operation(OP.NONE))
         merging_data = set(drs.data)
         my_data = set(self.data)
         new_data = my_data - merging_data
-        self.set_data(list(new_data))
+        # self.set_data(list(new_data))
+        result.set_data(list(new_data))
         # Merge provenance
         # FIXME: perhaps we need to do some garbage collection of the prov
         # graph at some point
-        self.absorb_provenance(drs)
+        # self.absorb_provenance(drs)
+        result.absorb_provenance(self)
+        result.absorb_provenance(drs)
         return self
 
     """

--- a/api/apiutils.py
+++ b/api/apiutils.py
@@ -66,7 +66,16 @@ class Relation(Enum):
     CONTAINER = 15
 
     def from_metadata(self):
-        return self.value >= 10
+        if self == \
+                Relation.MEANS_SAME or self == \
+                Relation.MEANS_DIFF or self == \
+                Relation.SUBCLASS or self == \
+                Relation.SUPERCLASS or self == \
+                Relation.MEMBER or self == \
+                Relation.CONTAINER:
+            return True
+        else:
+            return False
 
 
 class OP(Enum):
@@ -481,6 +490,7 @@ class DRS:
         # FIXME: or alternatively perform a more fine-grained merging
         # self.absorb_provenance(drs, annotate_and_edges=True)
         result.absorb_provenance(drs, annotate_and_edges=True)
+        result.absorb_provenance(self, annotate_and_edges=True)
         return result
 
     def union(self, drs):

--- a/api/apiutils.py
+++ b/api/apiutils.py
@@ -66,16 +66,7 @@ class Relation(Enum):
     CONTAINER = 15
 
     def from_metadata(self):
-        if self == \
-                Relation.MEANS_SAME or self == \
-                Relation.MEANS_DIFF or self == \
-                Relation.SUBCLASS or self == \
-                Relation.SUPERCLASS or self == \
-                Relation.MEMBER or self == \
-                Relation.CONTAINER:
-            return True
-        else:
-            return False
+        return self.value >= 10
 
 
 class OP(Enum):

--- a/api/apiutils.py
+++ b/api/apiutils.py
@@ -458,6 +458,7 @@ class DRS:
     def intersection(self, drs):
         # Reset ranking
         self._ranked = False
+        result = DRS([], Operation(OP.NONE))
         new_data = []
         # FIXME: There are more efficient ways of doing this
         if drs.mode == DRSMode.TABLE:
@@ -473,12 +474,14 @@ class DRS:
             my_data = set(self.data)
             new_data = list(merging_data.intersection(my_data))
         # We set the new data into our DRS again
-        self.set_data(new_data)
+        # self.set_data(new_data)
+        result.set_data(new_data)
         # Merge provenance
         # FIXME: perhaps we need to do some garbage collection of the prov graph at some point
         # FIXME: or alternatively perform a more fine-grained merging
-        self.absorb_provenance(drs, annotate_and_edges=True)
-        return self
+        # self.absorb_provenance(drs, annotate_and_edges=True)
+        result.absorb_provenance(drs, annotate_and_edges=True)
+        return result
 
     def union(self, drs):
         # Reset ranking

--- a/api/apiutils.py
+++ b/api/apiutils.py
@@ -66,7 +66,16 @@ class Relation(Enum):
     CONTAINER = 15
 
     def from_metadata(self):
-        return self.value >= 10
+        if self == \
+                Relation.MEANS_SAME or self == \
+                Relation.MEANS_DIFF or self == \
+                Relation.SUBCLASS or self == \
+                Relation.SUPERCLASS or self == \
+                Relation.MEMBER or self == \
+                Relation.CONTAINER:
+            return True
+        else:
+            return False
 
 
 class OP(Enum):


### PR DESCRIPTION
Fixing the problem of storing the results of intersection of two DRSs in the first DRS -- I use a temporary object to store the intersection without overwriting the original objects