### PR TITLE
fix: bug in function apply_filter

### DIFF
--- a/DoD/data_processing_utils.py
+++ b/DoD/data_processing_utils.py
@@ -310,9 +310,9 @@ def apply_filter(relation_path, attribute, cell_value):
     #     cache[relation_path] = df
     df = read_relation_on_copy(relation_path)  # FIXME FIXE FIXME
     # df = get_dataframe(relation_path)
-    df[attribute] = df[attribute].apply(lambda x: str(x).lower())
+    df[attribute] = df[attribute].apply(lambda x: str(x).lower().strip())
     # update_relation_cache(relation_path, df)
-    df = df[df[attribute] == cell_value]
+    df = df[df[attribute] == str(cell_value).lower()]
     return df
 
 


### PR DESCRIPTION
**Bug Description:**
For the following testcase on TPCH dataset
attrs = ["s_name", "s_address", "n_name"] values = ["Supplier#000000001", '',''] (candidate tables: supply.csv, nation.csv)
DOD failed to find the correct view and mistakenly judged that the join path between supply.csv and nation.csv is not materializable.
**Reason:**
The bug is resulted from the function apply_filter. This function fails to check the value constraint correctly since it does not trim cell values in the table. For the bug above, we are actually comparing "supplier#000000001" with "supplier#000000001+spaces". That's why it gives the wrong answer.
**Fix:**
Use strip() to trim cell values in advance.
  